### PR TITLE
404 message appears beside menu

### DIFF
--- a/action.php
+++ b/action.php
@@ -7,25 +7,12 @@ require_once(DOKU_PLUGIN.'action.php');
 class action_plugin_notfound extends DokuWiki_Action_Plugin {
 
     function register(Doku_Event_Handler $controller) {
-        $controller->register_hook('ACTION_ACT_PREPROCESS','BEFORE', $this, '_check404');
         $controller->register_hook('TPL_CONTENT_DISPLAY','BEFORE', $this, '_show404');
     }
 
-
-    function _check404(&$event , $param) {
-        if($event->data != 'show') return false;
-        global $INFO;
-        if($INFO['exists']) return false;
-
-        $event->data = 'notfound';
-        $event->stopPropagation();
-        $event->preventDefault();
-        return true;
-    }
-
     function _show404(&$event, $param) {
-        global $ACT;
-        if($ACT != 'notfound') return false;
+        global $ACT, $INFO;
+        if($ACT != 'show' || $INFO['exists']) return false;
         $event->stopPropagation();
         $event->preventDefault();
 
@@ -34,7 +21,6 @@ class action_plugin_notfound extends DokuWiki_Action_Plugin {
         $ID = $this->getConf('404page');
         echo p_wiki_xhtml($ID,'',false);
         $ID = $oldid;
-        $ACT='show';
 
         return true;
     }


### PR DESCRIPTION
This PR is not strictly necessary, but I prefer the 404 message beside the menu, not over it.
This way it's possible to tell the user to click on one of the menu links.